### PR TITLE
Fix wrappers and buffers

### DIFF
--- a/metamotivo/fb_cpr/agent.py
+++ b/metamotivo/fb_cpr/agent.py
@@ -156,7 +156,7 @@ class FBcprAgent(FBAgent):
             expert_obs=expert_obs, expert_z=expert_z, train_obs=train_obs, train_z=train_z, grad_penalty=grad_penalty
         )
 
-        z = self.sample_mixed_z(train_goal=train_next_obs, expert_encodings=expert_z) + 0 # fast copy
+        z = self.sample_mixed_z(train_goal=train_next_obs, expert_encodings=expert_z).clone()
         self.z_buffer.add(z)
 
         if self.cfg.train.relabel_ratio is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "Inference and Training of FB-CPR"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "safetensors>=0.4.4",
     "torch>=2.3",
-    "safetensors",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inference and Training of FB-CPR"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "safetensors>=0.4.4",
+    "safetensors>=0.4.5",
     "torch>=2.3",
 ]
 


### PR DESCRIPTION
## Fixes and logic changes

1. Add missing priorities in the trajectory buffer
2. Fix cloning of `z`s in mixed sampling of the fb and fb_cpr agents
3. Add load and save in the fb agent
4. Fixes in reward inference (detach tensors and move to numpy)
5. Improvement in relabeling (do not create multiprocessing version if `max_workers==1`
6. Fix`get_full_buffer`

## Dependencies:

1. Specify `safetensors>=0.4.5`, before there was no requirement of version